### PR TITLE
Change product-card color scheme

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -4,6 +4,10 @@ html, body{
   color: #171b23
 }
 
+body {
+  background-color: #eeeced;
+}
+
 a.active {
   background-color: gray;
 }
@@ -38,11 +42,13 @@ a {
 .search-result {
   float: left;
   width: 95%;
-  margin: 10px;
-  background: #eeeced;
-  border: solid 3px #eeeced;
-  border-radius: 15px;
   height: 230px;
+  margin: 10px;
+  color: #555;
+  background: white;
+  border: solid 1px #ddd;
+  box-shadow: 0px 0px 5px rgba(50,50,50,0.5);
+  border-radius: 15px;
 }
 
 .search-result a {
@@ -64,6 +70,7 @@ a {
   max-width: 100%;
   max-height: 100%;
   object-fit: contain;
+  object-position: top;
 }
 
 .game-left {

--- a/src/styles/headings.css
+++ b/src/styles/headings.css
@@ -1,3 +1,4 @@
 h1 {
   color: #00BCD4;
+  font-size: 24px;
 }


### PR DESCRIPTION
Since product-images often have ugly white, non-transparent backgrounds, it might look nicer if the product-cards were white as well. Tried out white cards on a gray page.

Bonus change: Tried a smaller fontsize for the store-names just so that the text "WorldOfBoardgames" didn't overflow it's column.

Before
![image](https://user-images.githubusercontent.com/3415677/81979166-d127df00-962c-11ea-96fd-0a1ce17f9ed4.png)


After
![image](https://user-images.githubusercontent.com/3415677/81979006-9cb42300-962c-11ea-9d52-6fea1a7e7621.png)
